### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ func main() {
   // Enable support on Windows for this application. It is safe to include on
   // OSes other than Windows, as the functions will only return nil; thus
   // compiled out.
-  escapes.EnableVirtualTerminal(escapes.Stdout)
-  defer escapes.DisableVirtualTerminal(escapes.Stdout)
+  escapes.EnableVirtualTerminal(os.Stdout.Fd())
+  defer escapes.DisableVirtualTerminal(os.Stdout.Fd())
 
   // Erase the screen. Remember that fmt.Println would print the newline *after*
   // the escape sequence.


### PR DESCRIPTION
I  had a bit of frustration trying to find out where the console handle is, since the one in the README was removed in af6561f4594c96327532e853b0255451085b18ff.
This will update the README to show the proper way of setting it up on Windows.