### PR TITLE
Fix toggle behavior of DisableVirtualTerminal

### DIFF
--- a/escapes_windows.go
+++ b/escapes_windows.go
@@ -32,7 +32,7 @@ func DisableVirtualTerminal(fd uintptr) error {
 	if err := syscall.GetConsoleMode(syscall.Handle(fd), &mode); err != nil {
 		return err
 	}
-	mode ^= windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	mode &^= windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
 
 	if err := windows.SetConsoleMode(windows.Handle(fd), mode); err != nil {
 		return err


### PR DESCRIPTION
The function `DisableVirtualTerminal` for Windows toggles the `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag on `mode`, due to an XOR operation (`^`). It was fix by changing it to an AND NOT operation (`&^`), so that the `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag on `mode` is always set to zero regardless of its previous state.